### PR TITLE
Switch back to uwsgiit-py

### DIFF
--- a/console/__init__.py
+++ b/console/__init__.py
@@ -7,7 +7,7 @@ __version__ = '.'.join((str(each) for each in VERSION[:4]))
 
 DJANGO_VERSION = '==1.7'
 SELECT2_VERSION = '==0.10'
-UWSGIIT_VERSION = '>=0.9.1'
+UWSGIIT_VERSION = '>=0.10.0'
 APPCONF_VERSION = '==0.6'
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'Django{}'.format(console.DJANGO_VERSION),
         'twentytab-select2{}'.format(console.SELECT2_VERSION),
         'django-appconf{}'.format(console.APPCONF_VERSION),
-        'uwsgiit-client{}'.format(console.UWSGIIT_VERSION)
+        'uwsgiit-py{}'.format(console.UWSGIIT_VERSION)
     ],
     packages=find_packages(exclude=['demo', 'demo.*']),
     include_package_data=True,


### PR DESCRIPTION
Instead of using a fork switch back to the upstream project since feature wise are the same. I recently added a test project for being able to the api against a local uwsgi_it_api installation to make it easier to run tests.